### PR TITLE
Add handling space subdomain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,24 @@
+name: Ruby CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.7", "3.0", "3.1"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 PATH
   remote: .
   specs:
-    omniauth_cobot (0.0.3)
+    omniauth_cobot (0.1.0)
       omniauth-oauth2 (~> 1.8.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
+    diff-lcs (1.5.0)
     faraday (2.6.0)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -32,6 +33,19 @@ GEM
     rack-protection (3.0.2)
       rack
     rake (13.0.1)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
     ruby2_keywords (0.0.5)
     snaky_hash (2.0.1)
       hashie
@@ -39,11 +53,12 @@ GEM
     version_gem (1.1.1)
 
 PLATFORMS
-  ruby
+  arm64-darwin-21
 
 DEPENDENCIES
   omniauth_cobot!
   rake
+  rspec (~> 3.12)
 
 BUNDLED WITH
-   1.16.1
+   2.3.20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   omniauth_cobot!

--- a/README.md
+++ b/README.md
@@ -6,13 +6,21 @@ This gem provides an [OmniAuth](https://github.com/intridea/omniauth) strategy f
 
 Add the following as an initializer:
 
-    Rails.application.config.middleware.use OmniAuth::Builder do
-      provider :cobot, '<client_id>', '<client_secret>', scope: 'read write'
-    end
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :cobot, '<client_id>', '<client_secret>', scope: 'read write'
+end
+```
 
-This gives you access to a variable `request.env['omniauth.auth']` in your authentication callback that looks like this:
+To authenticate a user against Cobot, send them to `/auth/cobot`.
 
-* `uid` - the id of the user
-* `credentials` - `{'token' => '<access token>'}`
-* `info` - `{'email' => '<user email>', 'picture' => '<url>'}`
-* `extra` - `{:raw_info => { "id": "<user id>", "email": "<email>", "picture": "<picture url>", "mac_addresses": ["<mac address>"...], "memberships": [{ "space_link": "<https://www.cobot.me/api/spaces/some-space>", "link": "<https://some-space.cobot.me/api/memberships/some-membership>" } ], "admin_of": [ { "space_link": "<https://www.cobot.me/api/spaces/some-space>", "name": "<admin name>" } ] }`
+If authenticating in the context of a Cobot space, e.g. if your app is inside an ifram on Cobot, pass the space's subdomain by sending the user to `/auth/cobot/cobot_space_subdomain=<space-sudbomain>`. This ensures users don't have to log in again for their space on Cobot when that space has a custom domain.
+
+After the user completed the OAuth flow, they are redirected back to `/auth/cobot/callback`, which should be routed to a controller action.
+
+In the controller action you have access to a variable `request.env['omniauth.auth']` that looks like this:
+
+- `uid` - the id of the user
+- `credentials` - `{'token' => '<access token>'}`
+- `info` - `{'email' => '<user email>', 'picture' => '<url>'}`
+- `extra` - `{:raw_info => { "id": "<user id>", "email": "<email>", "picture": "<picture url>", "mac_addresses": ["<mac address>"...], "memberships": [{ "space_link": "<https://www.cobot.me/api/spaces/some-space>", "link": "<https://some-space.cobot.me/api/memberships/some-membership>" } ], "admin_of": [ { "space_link": "<https://www.cobot.me/api/spaces/some-space>", "name": "<admin name>" } ] }`

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,11 @@
 require 'bundler'
 Bundler::GemHelper.install_tasks
+
+require 'rspec/core/rake_task'
+
+task default: [:spec]
+
+desc "Run the specs."
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = "spec/**/*_spec.rb"
+end

--- a/lib/omniauth/strategies/cobot.rb
+++ b/lib/omniauth/strategies/cobot.rb
@@ -9,6 +9,27 @@ module OmniAuth
         :token_url => 'https://www.cobot.me/oauth/access_token'
       }
 
+      def client
+        ::OAuth2::Client.new(
+          options.client_id, 
+          options.client_secret, 
+          deep_symbolize(
+            options.client_options.merge(
+              authorize_url: space_subdomain_authorize_url
+            )
+          )
+        )
+      end
+  
+      def space_subdomain_authorize_url
+        params = Rack::Utils.parse_nested_query(env['QUERY_STRING'])
+        if (subdomain = params['cobot_space_subdomain'])
+          options.client_options[:authorize_url].sub('www.', "#{subdomain}.")
+        else
+          options.client_options[:authorize_url]
+        end
+      end
+
       uid { raw_info['id'] }
 
       info do

--- a/omniauth_cobot.gemspec
+++ b/omniauth_cobot.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'omniauth-oauth2', '~>1.8.0'
 
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec', '~>3.12'
 
   s.files         = `git ls-files`.split("\n")
-  # s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.test_files    = `git ls-files -- spec/*`.split("\n")
   # s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'omniauth_cobot'

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe OmniAuth::Strategies::Cobot do
+  let(:app) do
+    lambda do |_env|
+      [200, {}, ["Hello."]]
+    end
+  end
+  let(:strategy) { Class.new(OmniAuth::Strategies::Cobot) }
+
+  before do
+    OmniAuth.config.test_mode = true
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+  end
+
+
+  it 'takes the cobot_space_sudomain query param and changes the subdomain of the authorize_url' do
+    subject = strategy
+      .new(app, client_options: {authorize_url: 'https://www.cobot.me'})
+
+    subject.call!(
+      {
+        'rack.session' => {},
+        'QUERY_STRING' => 'cobot_space_subdomain=my-space'
+      }
+    )
+    
+    expect(subject.client.authorize_url)
+      .to eq('https://my-space.cobot.me')
+  end
+
+  it 'does not change the subdomain of the authorize_url when no cobot_space_subdomain passed' do
+    subject = strategy
+      .new(app, client_options: {authorize_url: 'https://www.cobot.me'})
+
+    subject.call!(
+      {
+        'rack.session' => {}
+      }
+    )
+    
+    expect(subject.client.authorize_url)
+      .to eq('https://www.cobot.me')
+  end
+
+  it 'does nothing if no authorize_url configured' do
+    subject = strategy
+      .new(app, {})
+
+    subject.call!(
+      {
+        'rack.session' => {}
+      }
+    )
+    
+    expect(subject.client.authorize_url)
+      .to eq('https://www.cobot.me/oauth/authorize')
+  end
+      
+end


### PR DESCRIPTION
When an app runs in a space's iframe on Cobot and that space has a custom domain, OAuth needs to use the custom domain and not www.cobot.me, otherwise users have to log in again when accessing the app. This is now accomplised by passing the space's subdomain to the `/auth/cobot` endpoint.